### PR TITLE
Add clang-tidy to ci workflow

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,58 @@
+---
+# Clang-tidy configuration for NextCV project
+---
+Checks: >
+  *,
+  -abseil-*,
+  -altera-*,
+  -android-*,
+  -fuchsia-*,
+  -google-*,
+  -llvm-*,
+  -zircon-*,
+  -llvmlibc-*,
+  -readability-identifier-length,
+  -readability-magic-numbers,
+  -readability-uppercase-literal-suffix,
+  -modernize-use-trailing-return-type,
+  -modernize-avoid-c-arrays,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -misc-non-private-member-variables-in-classes,
+  -bugprone-easily-swappable-parameters,
+  -misc-include-cleaner
+
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+AnalyzeTemporaryDtors: false
+FormatStyle: 'file'
+CheckOptions:
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.FunctionCase
+    value: camelBack
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
+  - key: readability-identifier-naming.ParameterCase
+    value: lower_case
+  - key: readability-identifier-naming.MemberCase
+    value: lower_case
+  - key: readability-identifier-naming.PrivateMemberPrefix
+    value: m_
+  - key: readability-identifier-naming.ProtectedMemberPrefix
+    value: m_
+  - key: readability-identifier-naming.EnumConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.ConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.StaticConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.ConstantMemberCase
+    value: UPPER_CASE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,8 +126,9 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang-format-17 clang-17
+          sudo apt-get install -y clang-format-17 clang-17 clang-tidy-17
           sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-17 100
+          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-17 100
 
       - name: 🛠️ Install Clang Tools (macOS)
         if: matrix.os == 'macos-latest'
@@ -138,6 +139,13 @@ jobs:
       - name: 🎨 Check C++ Format
         run: |
           clang-format --dry-run --Werror ${{ needs.changed-files.outputs.cpp }}
+
+      - name: 🔍 Run clang-tidy
+        run: |
+          # Generate compile_commands.json for clang-tidy
+          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DNEXTCV_BUILD_PYTHON=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          # Run clang-tidy on changed C++ files
+          clang-tidy --config-file=.clang-tidy ${{ needs.changed-files.outputs.cpp }} -- -I build -I nextcv/_cpp/src
 
       - name: 🔨 Build C++ Examples
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,45 +1,52 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-  - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+-   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
     rev: v0.8.0
     hooks:
-      - id: pre-commit-update
+    -   id: pre-commit-update
 
-  - repo: https://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
         exclude: mkdocs.yml
-      - id: check-added-large-files
+    -   id: check-added-large-files
         args: ["--maxkb=1500"]
-      - id: check-json
+    -   id: check-json
         exclude: .vscode/settings.json
-      - id: pretty-format-json
+    -   id: pretty-format-json
         args: [--autofix, --no-sort-keys]
         exclude: ^(.vscode/settings\\.json|.*\\.ipynb)$
-      - id: check-case-conflict
-      - id: name-tests-test
+    -   id: check-case-conflict
+    -   id: name-tests-test
         args: [--pytest-test-first]
 
-  - repo: https://github.com/gitleaks/gitleaks
+-   repo: https://github.com/gitleaks/gitleaks
     rev: v8.28.0
     hooks:
-      - id: gitleaks
+    -   id: gitleaks
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
+-   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.13.0
     hooks:
       # Run the linter.
-      - id: ruff
+    -   id: ruff
         args: [--fix]
-      - id: ruff-format
+    -   id: ruff-format
 
-  - repo: https://github.com/pre-commit/mirrors-clang-format
+-   repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v21.1.0
     hooks:
-      - id: clang-format
+    -   id: clang-format
         types_or: [c, c++, cuda]
+
+-   repo: https://github.com/pocc/pre-commit-hooks
+    rev: v1.3.5
+    hooks:
+    -   id: clang-tidy
+        args: [--config-file=.clang-tidy]
+        types_or: [c++, c]


### PR DESCRIPTION
Add clang-tidy to the project for improved C++ code quality checks in CI and pre-commit.

The initial `.clang-tidy` configuration disables noisy checks (e.g., `llvmlibc`, `abseil`) and focuses on modern C++ best practices, readability, and naming conventions. It's integrated into the CI workflow to run on changed C++ files and as a pre-commit hook to catch issues early.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c830f76-3e28-4591-b7f6-2f999ab36d74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6c830f76-3e28-4591-b7f6-2f999ab36d74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

