### PR TITLE
Integrate eigen matrix-vector multiplication via pybind11

### DIFF
--- a/examples/eigen_example.py
+++ b/examples/eigen_example.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Example demonstrating Eigen matrix-vector multiplication in NextCV."""
+
+import numpy as np
+import sys
+import os
+
+# Add the build directory to Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'build', 'nextcv', '_cpp', 'src'))
+
+from nextcv_py import linalg as cpp_linalg
+
+def main():
+    print("NextCV Eigen Matrix-Vector Multiplication Example")
+    print("=" * 50)
+    
+    # Create test data
+    rng = np.random.default_rng(42)
+    
+    # Matrix A: 4x3
+    A = rng.standard_normal((4, 3)).astype(np.float32)
+    print(f"Matrix A ({A.shape}):")
+    print(A)
+    print()
+    
+    # Vector x: 3x1
+    x = rng.standard_normal((3,)).astype(np.float32)
+    print(f"Vector x ({x.shape}):")
+    print(x)
+    print()
+    
+    # Compute using NextCV (Eigen)
+    y_cpp = cpp_linalg.matvec(A, x)
+    print(f"Result y = A @ x using NextCV (Eigen):")
+    print(f"  Shape: {y_cpp.shape}, dtype: {y_cpp.dtype}")
+    print(f"  Values: {y_cpp}")
+    print()
+    
+    # Compare with NumPy
+    y_np = A @ x
+    print(f"Result y = A @ x using NumPy:")
+    print(f"  Shape: {y_np.shape}, dtype: {y_np.dtype}")
+    print(f"  Values: {y_np}")
+    print()
+    
+    # Verify they match
+    if np.allclose(y_cpp, y_np, rtol=1e-6, atol=1e-6):
+        print("✓ Results match perfectly!")
+    else:
+        print("✗ Results differ!")
+    
+    print()
+    print("Example completed successfully!")
+
+if __name__ == "__main__":
+    main()

--- a/nextcv/_cpp/src/CMakeLists.txt
+++ b/nextcv/_cpp/src/CMakeLists.txt
@@ -1,5 +1,8 @@
 # Modern CMake with automatic source discovery
 
+# Eigen (header-only)
+find_package(Eigen3 3.3 REQUIRED NO_MODULE)
+
 # Create NextCV core library
 file(GLOB_RECURSE NEXTCV_SOURCES "*.cpp")
 list(FILTER NEXTCV_SOURCES EXCLUDE REGEX "bindings/.*")
@@ -13,6 +16,9 @@ target_include_directories(nextcv
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include/nextcv>
 )
+
+# Link Eigen to the core library
+target_link_libraries(nextcv PUBLIC Eigen3::Eigen)
 
 # Set library properties
 set_target_properties(nextcv PROPERTIES
@@ -31,7 +37,7 @@ if(NEXTCV_BUILD_PYTHON)
   pybind11_add_module(nextcv_py MODULE ${BINDINGS_SOURCES})
 
   # Link core library
-  target_link_libraries(nextcv_py PRIVATE nextcv)
+  target_link_libraries(nextcv_py PRIVATE nextcv pybind11::module pybind11::headers)
 
   # Ensure NumPy includes are available (fallback if CMake find_package fails)
   if(NOT Python3_NumPy_INCLUDE_DIRS)

--- a/nextcv/_cpp/src/bindings/bindings.cpp
+++ b/nextcv/_cpp/src/bindings/bindings.cpp
@@ -2,10 +2,12 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>
+#include <pybind11/eigen.h>   // Eigen <-> NumPy conversions
 
 #include "../core/hello.hpp"
 #include "../image/invert.hpp"
 #include "../postprocessing/nms.hpp"
+#include "../linalg/matvec.hpp"
 
 namespace py = pybind11;
 
@@ -49,4 +51,17 @@ PYBIND11_MODULE(nextcv_py, module) {
     module.def("nms", &nextcv::postprocessing::nms, py::arg("bboxes"), py::arg("scores"),
                py::arg("threshold") = 0.5f,
                "Apply Non-Maximum Suppression to bounding boxes (numpy arrays)");
+
+    // Linear algebra submodule
+    auto linalg = module.def_submodule("linalg", "Linear algebra utilities");
+
+    // Accepts np.float32 arrays; returns np.float32 vector.
+    linalg.def(
+        "matvec",
+        [](const Eigen::Ref<const Eigen::MatrixXf>& A,
+           const Eigen::Ref<const Eigen::VectorXf>& x) {
+          return nextcv::linalg::matvec(A, x);
+        },
+        py::arg("A"), py::arg("x"),
+        R"doc(Multiply matrix A (M×N) by vector x (N) → y (M). Uses Eigen.)doc");
 }

--- a/nextcv/_cpp/src/linalg/matvec.cpp
+++ b/nextcv/_cpp/src/linalg/matvec.cpp
@@ -1,0 +1,15 @@
+#include "matvec.hpp"
+
+namespace nextcv::linalg {
+
+auto matvec(const Eigen::Ref<const Eigen::MatrixXf>& A,
+            const Eigen::Ref<const Eigen::VectorXf>& x) -> Eigen::VectorXf {
+  if (A.cols() != x.size()) {
+    throw std::invalid_argument(
+        "matvec: shape mismatch: A is " + std::to_string(A.rows()) + "x" +
+        std::to_string(A.cols()) + ", x is " + std::to_string(x.size()));
+  }
+  return A * x;  // Eigen handles allocation and optimized kernel
+}
+
+}  // namespace nextcv::linalg

--- a/nextcv/_cpp/src/linalg/matvec.hpp
+++ b/nextcv/_cpp/src/linalg/matvec.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include <Eigen/Core>
+#include <stdexcept>
+#include <string>
+
+namespace nextcv::linalg {
+
+// Multiply A (M×N) by x (N) → y (M).
+// Using Ref avoids copies and enables zero-copy views from NumPy when contiguous.
+auto matvec(const Eigen::Ref<const Eigen::MatrixXf>& A,
+            const Eigen::Ref<const Eigen::VectorXf>& x)
+    -> Eigen::VectorXf;
+
+}  // namespace nextcv::linalg


### PR DESCRIPTION
Add Eigen matrix-vector multiplication to NextCV's C++ core and expose it via pybind11 to enable efficient linear algebra operations with zero-copy NumPy integration.

---
<a href="https://cursor.com/background-agent?bcId=bc-54611b86-52c1-4b08-8229-b9f344510287">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-54611b86-52c1-4b08-8229-b9f344510287">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

