### PR TITLE
Install eigen for docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,11 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
+      - name: 🔧 Install Eigen3
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libeigen3-dev
+
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           fetch-depth: 0 # Need full history for changelog generation
 
+      - name: 🔧 Install Eigen3
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libeigen3-dev
+
       - name: 🐍 Setup Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Add Eigen3 installation step to `docs.yml` to fix documentation deployment failures.

The `docs.yml` workflow was missing the `libeigen3-dev` installation step, which is present in the `ci.yml` workflow. This omission led to build failures during documentation deployment, as Eigen was a required dependency. This change ensures Eigen is available, resolving the deployment issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-e50b6eca-5746-41e1-8a12-10a1ef696324">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e50b6eca-5746-41e1-8a12-10a1ef696324">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

