### PR TITLE
Add Eigen Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ print(f"   nms_np(): {len(result_np)} boxes kept in {np_time * 1000:.2f}ms")
 
 ## How do I use it?
 
+### Prerequisites
+
+NextCV requires **Eigen3** for linear algebra operations. Install it first:
+
+=== "macOS"
+
+    ```bash
+    # Using Homebrew (recommended)
+    brew install eigen
+    ```
+
+=== "Linux"
+
+    ```bash
+    # Ubuntu/Debian
+    sudo apt-get install libeigen3-dev
+    ```
+
 ### Installation
 
 Get it, obviously. Use `uv` if you know what's good for you.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ This directory contains the documentation for NextCV, built with MkDocs and Mate
 
 ```bash
 # Using uv (recommended)
-uv sync --all-extras --no-extra cuda
+uv sync --all-extras
 
 # Or with pip
 pip install -e ".[docs]"
@@ -40,10 +40,7 @@ mkdocs gh-deploy
 
 ```
 docs/
-├── index.md              # Homepage
-├── getting-started.md    # Getting started guide
-├── pybind11-guide.md     # PyBind11 development guide
-├── examples/             # Code examples
+├── ...
 ├── includes/             # Shared content
 │   └── abbreviations.md  # Abbreviations
 ├── gen_ref_pages.py      # Auto-generate API reference
@@ -63,40 +60,6 @@ docs/
 - **API Reference**: Generated from Python docstrings using `gen_ref_pages.py`
 - **CLI Documentation**: Generated using `gen_cli_pages.py`
 
-### Styling
-
-The documentation uses the Material theme with custom styling. Key features:
-
-- Dark/light mode toggle
-- Code syntax highlighting
-- Search functionality
-- Mobile-responsive design
-- Navigation tabs and sections
-
-## 📚 Writing Guidelines
-
-### Tone
-
-Keep the tone somewhere between MKBHD and Linus Tech Tips:
-- Technical but accessible
-- Enthusiastic about performance
-- Clear explanations with practical examples
-- Use emojis sparingly but effectively
-
-### Code Examples
-
-- Always include working code examples
-- Show both C++ and Python implementations when relevant
-- Include performance comparisons
-- Add error handling examples
-
-### Structure
-
-- Start with a brief overview
-- Provide quick start examples
-- Include detailed explanations
-- End with next steps or related resources
-
 ## 🔧 Configuration
 
 The documentation is configured in `mkdocs.yml`:
@@ -110,15 +73,13 @@ The documentation is configured in `mkdocs.yml`:
 Documentation is automatically deployed to GitHub Pages when:
 
 - Pushing to `main` branch
-- Pushing to `develop` branch
-- Creating pull requests (preview only)
 
 The deployment is handled by the GitHub Actions workflow in `.github/workflows/docs.yml`.
 
 ## 🤝 Contributing
 
 1. Make changes to the documentation
-2. Test locally with `mkdocs serve`
+2. Test locally with `mkdocs serve` or `uv run mkdocs serve`
 3. Submit a pull request
 4. Documentation will be automatically deployed on merge
 

--- a/docs/home/getting-started.md
+++ b/docs/home/getting-started.md
@@ -2,7 +2,25 @@
 
 This guide will walk you through installing NextCV and running your first performance demo.
 
-## 1. Installation
+## 1. Prerequisites
+
+NextCV requires **Eigen3** for linear algebra operations. Install it first:
+
+=== "macOS"
+
+    ```bash
+    # Using Homebrew (recommended)
+    brew install eigen
+    ```
+
+=== "Linux"
+
+    ```bash
+    # Ubuntu/Debian
+    sudo apt-get install libeigen3-dev
+    ```
+
+## 2. Installation
 
 You can install NextCV using `uv` (recommended) or `pip`.
 
@@ -14,7 +32,7 @@ uv add git+https://github.com/kevinconka/nextcv.git
 pip install git+https://github.com/kevinconka/nextcv.git
 ```
 
-## 2. Performance Demo
+## 3. Performance Demo
 
 This example demonstrates the performance difference between the C++ and NumPy implementations of Non-Maximum Suppression (NMS).
 
@@ -54,7 +72,7 @@ Post-processing (NMS timing comparison):
    nms_np(): 949 boxes kept in 65.39ms
 ```
 
-## 3. Next Steps
+## 4. Next Steps
 
 Now that you have NextCV installed, you can start exploring the API.
 

--- a/docs/home/getting-started.md
+++ b/docs/home/getting-started.md
@@ -6,31 +6,31 @@ This guide will walk you through installing NextCV and running your first perfor
 
 NextCV requires **Eigen3** for linear algebra operations. Install it first:
 
-=== "macOS"
-
-    ```bash
-    # Using Homebrew (recommended)
-    brew install eigen
-    ```
-
 === "Linux"
 
     ```bash
-    # Ubuntu/Debian
     sudo apt-get install libeigen3-dev
+    ```
+
+=== "macOS"
+
+    ```bash
+    brew install eigen
     ```
 
 ## 2. Installation
 
-You can install NextCV using `uv` (recommended) or `pip`.
+=== "pip"
 
-```bash
-# Using uv (recommended)
-uv add git+https://github.com/kevinconka/nextcv.git
+      ```bash
+      pip install git+https://github.com/kevinconka/nextcv.git
+      ```
 
-# Or with pip
-pip install git+https://github.com/kevinconka/nextcv.git
-```
+=== "uv"
+
+      ```bash
+      uv add git+https://github.com/kevinconka/nextcv.git
+      ```
 
 ## 3. Performance Demo
 
@@ -76,5 +76,5 @@ Post-processing (NMS timing comparison):
 
 Now that you have NextCV installed, you can start exploring the API.
 
-- **Explore the API:** Check out the [API Reference](reference/) for a full list of available functions.
-- **Learn about our philosophy:** Read our guide on [When to Use C++](pybind11/when-to-use-cpp.md) to understand our approach to performance.
+- **Explore the API:** Check out the [API Reference](../reference) for a full list of available functions.
+- **Learn about our philosophy:** Read our guide on [When to Use C++](../pybind11/when-to-use-cpp.md) to understand our approach to performance.

--- a/docs/home/index.md
+++ b/docs/home/index.md
@@ -26,7 +26,7 @@ Ready to give it a try? Our [Getting Started](getting-started.md) guide will hav
 
 - **[Why NextCV?](../pybind11/index.md)** Learn about our approach to "smart performance".
 - **[When to Use C++?](../pybind11/when-to-use-cpp.md)** Our guide to making pragmatic performance decisions.
-- **[API Reference](../reference/)** A full list of available functions.
+- **[API Reference](../reference)** A full list of available functions.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,7 @@ nav:
       - When to Use C++: pybind11/when-to-use-cpp.md
       - PyBind11 Basics: pybind11/pybind11-basics.md
       - PyBind11 Testing: pybind11/testing.md
-      - PyBind11 Best Practices: pybild11/best-practices.md
+      - PyBind11 Best Practices: pybind11/best-practices.md
       - Resources: pybind11/resources.md
   - API Reference: reference/
   - Examples: examples/
@@ -113,7 +113,7 @@ plugins:
   - gen-files:
       scripts:
         - docs/gen_ref_pages.py
-        - docs/gen_cli_pages.py
+        # - docs/gen_cli_pages.py
   - literate-nav:
       nav_file: SUMMARY.md
   - mkdocstrings:


### PR DESCRIPTION
### Summary
Added essential Eigen3 installation instructions with visual tabs for macOS and Linux.

### Changes
- **README.md**: Added Prerequisites section with tabbed OS instructions
- **docs/home/getting-started.md**: Added Prerequisites section and enhanced Installation with package manager tabs
- **mkdocs.yml**: Fixed typo and disabled CLI generation

### Installation Instructions
```bash
# macOS
brew install eigen

# Linux
sudo apt-get install libeigen3-dev
```

Uses Material for MkDocs tabbed syntax for better visual presentation.