### PR TITLE
Add Python 3.6 Compatibility and Enhanced CI Testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9"]
         include:
           - os: ubuntu-latest
+            python-version: "3.6"
+            legacy: true
+            setup-deps: |
+              sudo apt-get update
+              sudo apt-get install -y libeigen3-dev
+          - os: ubuntu-latest
+            python-version: "3.10"
+            legacy: false
             setup-deps: |
               sudo apt-get update
               sudo apt-get install -y libeigen3-dev
           - os: macos-latest
+            python-version: "3.10"
+            legacy: false
             setup-deps: |
               brew install eigen
     runs-on: ${{ matrix.os }}
@@ -76,20 +84,37 @@ jobs:
       - name: 🔧 Install System Dependencies
         run: ${{ matrix.setup-deps }}
 
+      - name: 🐧 Setup Legacy Configuration
+        if: matrix.legacy == true
+        run: |
+          echo "Setting up legacy build for Python ${{ matrix.python-version }} compatibility..."
+          cp pyproject.legacy.toml pyproject.toml
+
       - name: 📦 Install uv
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: 🔧 Install Python Dependencies
-        run: uv sync
+      - name: 🔧 Install Python Dependencies (Legacy)
+        if: matrix.legacy == true
+        run: |
+          echo "Installing with pip for legacy Python ${{ matrix.python-version }}..."
+          pip install -e ".[dev]"
+
+      - name: 🔧 Install Python Dependencies (Modern)
+        if: matrix.legacy != true
+        run: |
+          echo "Installing with uv for modern Python ${{ matrix.python-version }}..."
+          uv sync
 
       - name: ✨ Lint & Format Check
+        if: matrix.legacy != true
         run: |
           uv run ruff check ${{ needs.changed-files.outputs.python }}
           uv run ruff format --check ${{ needs.changed-files.outputs.python }}
 
       - name: 📝 Generate and Check Python Stubs
+        if: matrix.legacy != true
         run: |
           uv run make stubs
           git diff nextcv/_cpp/ || true
@@ -98,8 +123,19 @@ jobs:
             exit 1
           )
 
-      - name: 🧪 Run Tests
+      - name: 🧪 Run Tests (Legacy)
+        if: matrix.legacy == true
         run: |
+          echo "Running tests with pytest for legacy Python ${{ matrix.python-version }}..."
+          pytest \
+            --cov-report=term-missing:skip-covered \
+            --junitxml=pytest.xml \
+            | tee pytest-coverage.txt
+
+      - name: 🧪 Run Tests (Modern)
+        if: matrix.legacy != true
+        run: |
+          echo "Running tests with uv for modern Python ${{ matrix.python-version }}..."
           uv run pytest \
             --cov-report=term-missing:skip-covered \
             --junitxml=pytest.xml \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,14 @@ jobs:
           echo "Setting up legacy build for Python ${{ matrix.python-version }} compatibility..."
           cp pyproject.legacy.toml pyproject.toml
 
+      - name: 📦 Install python
+        if: matrix.legacy == true
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: 📦 Install uv
+        if: matrix.legacy != true
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -113,8 +120,8 @@ jobs:
           uv run ruff check ${{ needs.changed-files.outputs.python }}
           uv run ruff format --check ${{ needs.changed-files.outputs.python }}
 
-      - name: 📝 Generate and Check Python Stubs
-        if: matrix.legacy != true
+      - name: 📝 Generate and Check Python Stubs (Ubuntu only)
+        if: matrix.legacy != true && startsWith(matrix.os, 'ubuntu')
         run: |
           uv run make stubs
           git diff nextcv/_cpp/ || true

--- a/nextcv/__init__.py
+++ b/nextcv/__init__.py
@@ -1,4 +1,4 @@
-"""NextCV: Computer Vision library with C++ and Python implementations.
+"""NextCV: Python-first computer vision library with C++ bdingings for speed.
 
 This package provides both high-performance C++ wrapped functions and
 pure Python implementations in functional modules.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ Build Commands:
     pip wheel --no-deps -w dist .
 
     # Install in development mode
-    pip install -e .
+    pip install -e ".[dev]"
 
 Note:
     For modern Python environments (3.9+), use pyproject.toml directly with
@@ -29,7 +29,15 @@ setup(
     packages=find_packages(include=["nextcv*"]),
     python_requires=">=3.6",
     install_requires=[
-        "numpy>=1.19.0",
-        "opencv-python>=4.4.0",
+        "numpy<1.19.5; python_version == '3.6'",
+        "numpy>=1.19.0; python_version > '3.6'",
+        "opencv-python-headless<4.7; python_version < '3.8'",
+        "opencv-python-headless>=4.4; python_version >= '3.8'",
     ],
+    extras_require={
+        "dev": [
+            "pytest>=7",
+            "pytest-cov>=4.0",
+        ]
+    },
 )


### PR DESCRIPTION
## What
Added Python 3.6 support and updated CI to test Python 3.6 (Ubuntu) + Python 3.10 (Ubuntu/macOS).

## Why
Support legacy Python 3.6 environments while maintaining modern tooling for newer versions.

## How
- **Dependencies**: Conditional NumPy/OpenCV versions + `[dev]` extras in `setup.py`
- **Build Systems**:
  - **Legacy (Python ≤3.9)**: `scikit-build` + `setup.py` + `pyproject.legacy.toml`
  - **Modern (Python ≥3.10)**: `scikit-build-core` + `uv` + `pyproject.toml`
- **CI**: Matrix strategy with native `if` conditions
  - **Legacy**: pip installation, skips linting/stub generation
  - **Modern**: uv installation, full linting/testing pipeline