### PR TITLE
PyPI publish: move to cibuildwheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,21 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            setup-deps: |
+              sudo apt-get update
+              sudo apt-get install -y libeigen3-dev
+          - os: macos-14
+            setup-deps: brew install eigen
+    runs-on: ${{ matrix.os }}
+    env:
+      # macOS: lower deployment target for broader compatibility (avoids libc++ ABI issues)
+      CMAKE_OSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '11.0' || '' }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '11.0' || '' }}
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
@@ -17,10 +31,8 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0 # Need full history for version (setuptools-scm)
 
-      - name: 🔧 Install Eigen3
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libeigen3-dev
+      - name: 🔧 Install build dependencies
+        run: ${{ matrix.setup-deps }}
 
       - name: 🐍 Setup Python
         uses: actions/setup-python@v6
@@ -30,13 +42,20 @@ jobs:
       - name: 📦 Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: 🏗️ Build sdist
-        run: uv build --sdist
+      - name: 🏗️ Build Package
+        run: uv build
+
+      - name: 🔧 Repair Linux wheel (auditwheel)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          uv pip install --system auditwheel
+          auditwheel repair dist/*.whl -w dist/
+          rm -f dist/*-linux_x86_64.whl
 
       - name: 📤 Upload dist
         uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-${{ matrix.os }}
           path: dist/
 
   publish:
@@ -46,11 +65,20 @@ jobs:
     permissions:
       id-token: write # Required for PyPI Trusted Publishing (OIDC)
     steps:
-      - name: 📥 Download dist
+      - name: 📥 Download all dist artifacts
         uses: actions/download-artifact@v4
         with:
-          name: dist
-          path: dist/
+          pattern: dist-*
+          path: artifacts
+
+      - name: 📦 Merge dist artifacts
+        run: |
+          mkdir -p dist
+          for dir in artifacts/dist-*; do
+            cp "$dir"/*.whl dist/ 2>/dev/null || true
+            cp "$dir"/*.tar.gz dist/ 2>/dev/null || true
+          done
+          ls -la dist/
 
       - name: 📦 Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,8 +48,10 @@ jobs:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
 
+      - uses: astral-sh/setup-uv@v7
+
       - name: Build sdist
-        run: pipx run build --sdist
+        run: uv build --sdist
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
       - name: 🔧 Repair Linux wheel (auditwheel)
         if: matrix.os == 'ubuntu-latest'
         run: |
-          uv pip install auditwheel
+          uv pip install --system auditwheel
           auditwheel repair dist/*.whl -w dist/
           rm -f dist/*-linux_x86_64.whl
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3
+        with:
+          extras: "uv"
         env:
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,11 @@
-name: Release
+name: Publish
 
 on:
-  push:
-    tags:
-      - "v*" # Trigger on any tag starting with 'v'
+  release:
+    types: [published]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -19,6 +18,7 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0 # Need full history for version (setuptools-scm)
 
       - name: 🔧 Install Eigen3
@@ -47,17 +47,17 @@ jobs:
           name: dist-${{ matrix.os }}
           path: dist/
 
-  release:
+  publish:
     needs: build
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      contents: write  # For GitHub Release
-      id-token: write  # Required for PyPI Trusted Publishing (OIDC)
+      id-token: write # Required for PyPI Trusted Publishing (OIDC)
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
 
       - name: 📥 Download all dist artifacts
@@ -80,9 +80,3 @@ jobs:
 
       - name: 📤 Publish to PyPI
         run: uv publish --trusted-publishing always
-
-      - name: 🚀 Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: dist/*
-          generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,80 +8,73 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            setup-deps: |
-              sudo apt-get update
-              sudo apt-get install -y libeigen3-dev
-          - os: macos-15
-            setup-deps: brew install eigen
-    runs-on: ${{ matrix.os }}
-    env:
-      # macOS: lower deployment target for broader compatibility
-      CMAKE_OSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-15' && '11.0' || '' }}
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-15' && '11.0' || '' }}
+          # Linux: manylinux wheels via cibuildwheel (auditwheel handles libc++)
+          - os: linux
+            runs-on: ubuntu-latest
+          # macOS: build on OLDEST runner for maximum compatibility
+          # Binary linked to macos-13's libc++ works on 13, 14, 15+ (Apple backward compat)
+          - os: macos
+            runs-on: macos-13
     steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name }}
-          fetch-depth: 0 # Need full history for version (setuptools-scm)
+          fetch-depth: 0  # required for setuptools-scm version
 
-      - name: 🔧 Install build dependencies
-        run: ${{ matrix.setup-deps }}
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3
+        env:
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
+          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
 
-      - name: 🐍 Setup Python
-        uses: actions/setup-python@v6
+      - uses: actions/upload-artifact@v4
         with:
-          python-version: "3.11"
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
 
-      - name: 📦 Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: 🏗️ Build Package
-        run: uv build
-
-      - name: 🔧 Repair Linux wheel (auditwheel)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          uv pip install --system auditwheel
-          auditwheel repair dist/*.whl -w dist/
-          rm -f dist/*-linux_x86_64.whl
-
-      - name: 📤 Upload dist
-        uses: actions/upload-artifact@v4
+  build_sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
         with:
-          name: dist-${{ matrix.os }}
-          path: dist/
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
 
   publish:
-    needs: build
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      id-token: write # Required for PyPI Trusted Publishing (OIDC)
+      id-token: write
     steps:
-      - name: 📥 Download all dist artifacts
-        uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v4
         with:
-          pattern: dist-*
+          pattern: "*"
           path: artifacts
 
-      - name: 📦 Merge dist artifacts
-        run: |
+      - run: |
           mkdir -p dist
-          for dir in artifacts/dist-*; do
-            cp "$dir"/*.whl dist/ 2>/dev/null || true
-            cp "$dir"/*.tar.gz dist/ 2>/dev/null || true
-          done
+          find artifacts -name "*.whl" -exec cp {} dist/ \;
+          find artifacts -name "*.tar.gz" -exec cp {} dist/ \;
           ls -la dist/
 
-      - name: 📦 Install uv
-        uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v7
 
-      - name: 📤 Publish to PyPI
+      - name: Publish to PyPI
         run: uv publish --trusted-publishing always

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,8 @@ jobs:
           # Linux: manylinux wheels via cibuildwheel (auditwheel handles libc++)
           - os: linux
             runs-on: ubuntu-latest
-          # macOS: build on OLDEST runner for maximum compatibility
-          # Binary linked to macos-13's libc++ works on 13, 14, 15+ (Apple backward compat)
           - os: macos
-            runs-on: macos-13
+            runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
         with:
@@ -31,7 +29,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3
         env:
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux*"
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,13 @@ jobs:
       - name: 🏗️ Build Package
         run: uv build
 
+      - name: 🔧 Repair Linux wheel (auditwheel)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          uv pip install auditwheel
+          auditwheel repair dist/*.whl -w dist/
+          rm -f dist/*-linux_x86_64.whl
+
       - name: 📤 Upload dist
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,13 +17,13 @@ jobs:
             setup-deps: |
               sudo apt-get update
               sudo apt-get install -y libeigen3-dev
-          - os: macos-14
+          - os: macos-15
             setup-deps: brew install eigen
     runs-on: ${{ matrix.os }}
     env:
-      # macOS: lower deployment target for broader compatibility (avoids libc++ ABI issues)
-      CMAKE_OSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '11.0' || '' }}
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '11.0' || '' }}
+      # macOS: lower deployment target for broader compatibility
+      CMAKE_OSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-15' && '11.0' || '' }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-15' && '11.0' || '' }}
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Publish
 
 on:
+  pull_request:
+    branches: [main]
   release:
     types: [published]
 
@@ -23,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || github.sha }}
           fetch-depth: 0  # required for setuptools-scm version
 
       - name: Build wheels
@@ -45,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || github.sha }}
           fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v7
@@ -64,6 +66,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
+    if: github.event_name == 'release'
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,7 @@ permissions:
 
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
@@ -23,12 +19,8 @@ jobs:
 
       - name: 🔧 Install Eigen3
         run: |
-          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            sudo apt-get update
-            sudo apt-get install -y libeigen3-dev
-          else
-            brew install eigen
-          fi
+          sudo apt-get update
+          sudo apt-get install -y libeigen3-dev
 
       - name: 🐍 Setup Python
         uses: actions/setup-python@v6
@@ -38,20 +30,13 @@ jobs:
       - name: 📦 Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: 🏗️ Build Package
-        run: uv build
-
-      - name: 🔧 Repair Linux wheel (auditwheel)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          uv pip install --system auditwheel
-          auditwheel repair dist/*.whl -w dist/
-          rm -f dist/*-linux_x86_64.whl
+      - name: 🏗️ Build sdist
+        run: uv build --sdist
 
       - name: 📤 Upload dist
         uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ matrix.os }}
+          name: dist
           path: dist/
 
   publish:
@@ -61,26 +46,11 @@ jobs:
     permissions:
       id-token: write # Required for PyPI Trusted Publishing (OIDC)
     steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.release.tag_name }}
-          fetch-depth: 0
-
-      - name: 📥 Download all dist artifacts
+      - name: 📥 Download dist
         uses: actions/download-artifact@v4
         with:
-          pattern: dist-*
-          path: artifacts
-
-      - name: 📦 Merge dist artifacts
-        run: |
-          mkdir -p dist
-          for dir in artifacts/dist-*; do
-            cp "$dir"/*.whl dist/ 2>/dev/null || true
-            cp "$dir"/*.tar.gz dist/ 2>/dev/null || true
-          done
-          ls -la dist/
+          name: dist
+          path: dist/
 
       - name: 📦 Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0  # required for setuptools-scm version
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3
+        uses: pypa/cibuildwheel@v3.4.0
         with:
           extras: "uv"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📤 Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        run: uv publish --trusted-publishing always
 
       - name: 🚀 Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: write  # For GitHub Release
+      id-token: write  # Required for PyPI Trusted Publishing (OIDC)
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
@@ -38,6 +42,9 @@ jobs:
       #   uses: mikepenz/release-changelog-builder-action@v5
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 📤 Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: 🚀 Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,22 +9,26 @@ permissions:
   contents: write
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      contents: write  # For GitHub Release
-      id-token: write  # Required for PyPI Trusted Publishing (OIDC)
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # Need full history for changelog generation
+          fetch-depth: 0 # Need full history for version (setuptools-scm)
 
       - name: 🔧 Install Eigen3
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libeigen3-dev
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            sudo apt-get update
+            sudo apt-get install -y libeigen3-dev
+          else
+            brew install eigen
+          fi
 
       - name: 🐍 Setup Python
         uses: actions/setup-python@v6
@@ -37,11 +41,42 @@ jobs:
       - name: 🏗️ Build Package
         run: uv build
 
-      # - name: 📝 Build Changelog
-      #   id: changelog
-      #   uses: mikepenz/release-changelog-builder-action@v5
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 📤 Upload dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+          path: dist/
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: write  # For GitHub Release
+      id-token: write  # Required for PyPI Trusted Publishing (OIDC)
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: 📥 Download all dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          path: artifacts
+
+      - name: 📦 Merge dist artifacts
+        run: |
+          mkdir -p dist
+          for dir in artifacts/dist-*; do
+            cp "$dir"/*.whl dist/ 2>/dev/null || true
+            cp "$dir"/*.tar.gz dist/ 2>/dev/null || true
+          done
+          ls -la dist/
+
+      - name: 📦 Install uv
+        uses: astral-sh/setup-uv@v7
 
       - name: 📤 Publish to PyPI
         run: uv publish --trusted-publishing always
@@ -49,6 +84,5 @@ jobs:
       - name: 🚀 Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          # body: ${{ steps.changelog.outputs.changelog }}
           files: dist/*
-          generate_release_notes: true # Adds GitHub's auto-generated notes too!
+          generate_release_notes: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ project(NextCV
 # Enable compile commands for tooling
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# macOS: support older versions (set via CMAKE_OSX_DEPLOYMENT_TARGET if not set)
+if(APPLE AND NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "Minimum macOS version")
+endif()
+
 
 # Set C++ standard globally (aligned with target_compile_features)
 set(CMAKE_CXX_STANDARD 20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,6 @@ project(NextCV
 # Enable compile commands for tooling
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# macOS: support older versions (set via CMAKE_OSX_DEPLOYMENT_TARGET if not set)
-if(APPLE AND NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "Minimum macOS version")
-endif()
-
-
 # Set C++ standard globally (aligned with target_compile_features)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ option(NEXTCV_BUILD_PYTHON "Build Python bindings" ON)
 
 # Find Python and pybind11 (compatible with scikit-build-core)
 if(NEXTCV_BUILD_PYTHON)
-  find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+  find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
   # Try to find NumPy component, but don't fail if not found (for scikit-build-core)
   find_package(Python3 COMPONENTS NumPy QUIET)
 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,20 @@ brew install eigen cmake
 ### Installation 📦
 
 ```bash
-# traditional pip
+# From PyPI (recommended)
+pip install nextcv
+
+# Or from git
 pip install git+https://github.com/kevinconka/nextcv.git
 
 # uv if you know what's good for you
-uv add git+https://github.com/kevinconka/nextcv.git
+uv add nextcv
+```
+
+**macOS:** If you get `symbol not found in flat namespace '__ZNSt3__113__hash_memoryEPKvm'`, the pre-built wheel may be incompatible with your system. Build from source instead:
+
+```bash
+CC=/usr/bin/clang CXX=/usr/bin/clang++ pip install nextcv --no-binary nextcv
 ```
 
 ### Check it's working ✅

--- a/README.md
+++ b/README.md
@@ -85,20 +85,13 @@ brew install eigen cmake
 ### Installation 📦
 
 ```bash
-# From PyPI (recommended)
 pip install nextcv
 
-# Or from git
+# or from git
 pip install git+https://github.com/kevinconka/nextcv.git
 
-# uv if you know what's good for you
+# uv
 uv add nextcv
-```
-
-**macOS:** If you get `symbol not found in flat namespace '__ZNSt3__113__hash_memoryEPKvm'`, the pre-built wheel may be incompatible with your system. Build from source instead:
-
-```bash
-CC=/usr/bin/clang CXX=/usr/bin/clang++ pip install nextcv --no-binary nextcv
 ```
 
 ### Check it's working ✅

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,22 @@ metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 version_scheme = "guess-next-dev"
 local_scheme = "no-local-version"
 
+# cibuildwheel configuration
+# https://cibuildwheel.readthedocs.io/
+[tool.cibuildwheel]
+build-frontend = "build"
+output-dir = "wheelhouse"
+
+# Linux: install Eigen (manylinux containers; EPEL needed on CentOS 7)
+[tool.cibuildwheel.linux]
+before-all = "yum install -y epel-release 2>/dev/null; yum install -y eigen3-devel || dnf install -y eigen3-devel"
+
+# macOS: build on oldest runner for maximum compatibility
+# Oldest libc++ = works on that version and all newer (Apple backward compat)
+[tool.cibuildwheel.macos]
+before-all = "brew install eigen"
+environment = { MACOSX_DEPLOYMENT_TARGET = "11.0", CMAKE_OSX_DEPLOYMENT_TARGET = "11.0" }
+
 # pytest configuration
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ local_scheme = "no-local-version"
 # cibuildwheel configuration
 # https://cibuildwheel.readthedocs.io/
 [tool.cibuildwheel]
-build-frontend = "build"
+build-frontend = "build[uv]"
 output-dir = "wheelhouse"
 
 # Linux: install Eigen (manylinux containers; EPEL needed on CentOS 7)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,10 +84,8 @@ output-dir = "wheelhouse"
 before-all = "yum install -y epel-release 2>/dev/null; yum install -y eigen3-devel || dnf install -y eigen3-devel"
 
 # macOS: build on oldest runner for maximum compatibility
-# Oldest libc++ = works on that version and all newer (Apple backward compat)
 [tool.cibuildwheel.macos]
 before-all = "brew install eigen"
-environment = { MACOSX_DEPLOYMENT_TARGET = "11.0", CMAKE_OSX_DEPLOYMENT_TARGET = "11.0" }
 
 # pytest configuration
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ local_scheme = "no-local-version"
 # https://cibuildwheel.readthedocs.io/
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
-output-dir = "wheelhouse"
 
 # Linux: install Eigen (manylinux containers; EPEL needed on CentOS 7)
 [tool.cibuildwheel.linux]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "nextcv"
 dynamic = ["version"] # <-- let setuptools-scm derive version
-description = "Python-first computer vision library with C++ bdingings for speed."
+description = "Python-first computer vision library with C++ bindings for speed."
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
**Changes vs main:**

- **publish.yml**: Replace manual wheel build with cibuildwheel
  - Linux: manylinux via cibuildwheel (auditwheel)
  - macOS: macos-latest
  - Python: 3.9–3.13
  - Separate `build_sdist` job using `uv build --sdist`
  - cibuildwheel extras: uv

- **pyproject.toml**: Add `[tool.cibuildwheel]`
  - `build-frontend = "build[uv]"`
  - `before-all` for Eigen on Linux and macOS

- **CMakeLists.txt**: Remove `CMAKE_OSX_DEPLOYMENT_TARGET` override

- **README.md**: Update install instructions